### PR TITLE
added '-clj' in klipse(-clj).test-runner-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ clj  -A:figwheel -C:test  --build test --repl
 # Tests - CI
 
 ```bash
-clj -A:figwheel -m klipse.test-runner-ci
+clj -A:figwheel -m klipse-clj.test-runner-ci
 ```


### PR DESCRIPTION
Just noticed the correct ns should be klipse-clj not only klipse as it was in the README.md in order to try the CI test