### PR TITLE
introduce shadow-cljs support and bump dependencies as necessary

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,21 +1,24 @@
 {:paths   ["src" "resources" "target" "test"]
- :deps    {org.clojure/clojure        {:mvn/version "1.10.0-RC5"}
-           org.clojure/clojurescript  #_{:git/url "https://github.com/clojure/clojurescript" :sha "6ccb629e365f46a9516e4defeced652cce9d4d35"} {:mvn/version "1.10.520"}
+ :deps    {org.clojure/clojure {:mvn/version "1.10.3"}
+           org.clojure/clojurescript {:mvn/version "1.10.879"}
+           com.google.javascript/closure-compiler-unshaded {:mvn/version "v20210505"}
            org.clojure/spec.alpha     {:mvn/version "0.2.176"}
-           org.clojure/tools.reader   {:mvn/version "1.3.2"}
-           org.clojure/core.async     {:mvn/version "0.4.474"}
+           org.clojure/tools.reader   {:mvn/version "1.3.6"}
+           org.clojure/core.async     {:mvn/version "1.3.618"}
            appliedscience/js-interop {:mvn/version "0.1.13"}
            viebel/codemirror-parinfer {:mvn/version "0.0.3"}
-           cljs-http                  {:mvn/version "0.1.42"}
-           viebel/gadjett             {:mvn/version "0.5.2"}}
+           cljs-http/cljs-http        {:mvn/version "0.1.46"}
+           viebel/gadjett             {:mvn/version "0.5.2"}
+           }
  :aliases {:fig {:extra-deps {cider/cider-nrepl {:mvn/version "0.18.0"}
                               cider/piggieback  {:mvn/version "0.3.9"}
                               com.bhauman/figwheel-main       {:mvn/version "0.1.9-SNAPSHOT"}
                               com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}}
            :bs {:extra-paths ["."]
                 :main-opts   ["-m bootstrap"]}
-           :test     {:extra-paths ["test"]}
-           :figwheel {:extra-deps {com.bhauman/figwheel-main       {:mvn/version "0.1.9"}
+           :shadow-cljs {:extra-deps {thheller/shadow-cljs {:mvn/version "2.15.3"}}
+                         :main-opts ["-m" "shadow.cljs.devtools.cli"]}
+           :figwheel {:extra-deps {com.bhauman/figwheel-main       {:mvn/version "0.2.14"}
                                    com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
                                    com.bhauman/cljs-test-display {:mvn/version "0.1.1"}}
                       :main-opts  ["-m" "figwheel.main"]}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,0 +1,11 @@
+{:source-paths ["src" "test"]
+ :dev-http     {8081 "resources/public"}
+ :nrepl        {:port 3333}
+ :builds {
+          :test {:modules {:test-main {:entries [klipse-clj.test-runner]}}
+                 :output-dir "target/public/cljs-out"
+                 :target :browser
+                 :compiler-options {:optimizations :none}
+                 }
+          }
+}

--- a/src/klipse_clj/lang/clojure.cljs
+++ b/src/klipse_clj/lang/clojure.cljs
@@ -130,9 +130,9 @@
               (advanced-compile value))]
     [status res]))
 
-(defn my-eval [{:keys [file source file lang name path cache] :as args}]
+(defn my-eval [{:keys [file source file lang name path cache]}]
   (watchdog)
-  (cljs/js-eval args))
+  (js/eval source))
 
 (defn eval-for-compilation [{:keys [source]}]
   source)

--- a/src/klipse_clj/lang/clojure.cljs
+++ b/src/klipse_clj/lang/clojure.cljs
@@ -26,12 +26,23 @@
 (declare core-eval-an-exp)
 
 
-(defn load-core-macros-cache []
-  (io/load-ns-from-file @st 'cljs.core$macros (str (io/bundled-ns-root) "/cljs/core$macros.cljc.cache.json")))
+(defn load-core-cache []
+  (js/eval "goog.isString = function(val) {return typeof val == 'string';};")
+  (js/eval "goog.isFunction = function(val) {return typeof val == 'function';};")
+  (go
+    (let [core-macros-loaded (io/load-ns-from-cache 'cljs.core (fn [res]
+                                                            (js/goog.globalEval (:source res))
+                                                            (cljs/load-analysis-cache! @st 'cljs.core$macros (:cache res))
+                                                            ) true nil)
+          core-loaded        (io/load-ns-from-cache 'cljs.core (fn [res]
+                                                                 (cljs/load-analysis-cache! @st 'cljs.core (:cache res))
+                                                                 ) false nil)]
+         (<! core-macros-loaded)
+         (<! core-loaded))))
 
 (defn init-custom-macros []
   (go
-    (<! (load-core-macros-cache))
+    (<! (load-core-cache))
     (doseq [my-macros ["(require '[klipse-clj.repl :refer-macros [doc]])"
                        "(require-macros '[klipse-clj.macros :refer [dbg inferred-type]])"]]
       (<! (first (core-eval-an-exp my-macros {:st @st :ns current-ns-eval}))))))
@@ -191,7 +202,7 @@
                          (go
                            (let [warnings (<! (read-until-closed! warnings-chan))]
                              (update-current-ns res verbose? ns)
-                             (put! res-chan res)                           
+                             (put! res-chan res)
                              (put! agg-warnings-chan (s/join "" warnings))))))
         [res-chan agg-warnings-chan]))))
 
@@ -405,5 +416,3 @@
   bbb
   (println 99)
   )
-
-

--- a/src/klipse_clj/lang/clojure/guard.cljs
+++ b/src/klipse_clj/lang/clojure/guard.cljs
@@ -9,7 +9,7 @@
     [gadjett.core :as gadjett :refer [dbg]]
     [cljs.core.async.macros :refer [go go-loop]])
   (:require
-    [cljs.analyzer :as ana]
+    [cljs.analyzer.impl :as ana-impl]
     [clojure.string :as s :refer [starts-with?]]
     [cljs.compiler :refer [emits emit *source-map-data*]]
     [cljs.core.async :refer [timeout chan put! <!]]))
@@ -68,8 +68,8 @@
   (doseq [x xs]
     (cond
      (nil? x) nil
-     (ana/cljs-map? x) (emit x)
-     (ana/cljs-seq? x) (apply my-emits max-eval-duration x); call my-emits recursively and not emits
+     (ana-impl/cljs-map? x) (emit x)
+     (ana-impl/cljs-seq? x) (apply my-emits max-eval-duration x); call my-emits recursively and not emits
      ^boolean (goog/isFunction x) (x)
      :else (let [s (print-str x)]
              (when-not (nil? *source-map-data*)
@@ -77,4 +77,3 @@
                  update-in [:gen-col] #(+ % (count s))))
              (print s))))
   nil)
-

--- a/test/klipse_clj/compile_test.cljs
+++ b/test/klipse_clj/compile_test.cljs
@@ -6,12 +6,14 @@
     [cljs.core.async :refer [<!]]
     [clojure.string :as string]
     [klipse-clj.repl :refer [reset-state-compile! reset-ns-compile!]]
-    [klipse-clj.lang.clojure :refer [str-compile]]))
+    [klipse-clj.lang.clojure :refer [str-compile create-state-eval]]))
 
 (use-fixtures :each
-              {:before (fn []
-                         (reset-state-compile!)
-                         (reset-ns-compile!))})
+              {:before #(async done
+                          (go (reset-state-compile!)
+                              (reset-ns-compile!)
+                              (<! (create-state-eval))
+                              (done)))})
 
 (defn remove-chars [s]
   (try
@@ -67,4 +69,3 @@
                  (a= (second (<! (str-compile input {:static-fns true}))) output)
                "(= 1 2)" "cljs.core._EQ_.cljs$core$IFn$_invoke$arity$2((1),(2));")
              (done))))
-

--- a/test/klipse_clj/test_runner.cljs
+++ b/test/klipse_clj/test_runner.cljs
@@ -1,19 +1,17 @@
-
 (ns klipse-clj.test-runner
   (:require
-    [klipse-clj.lang.clojure.io]
     [cljs-test-display.core]
     [cljs.test :refer-macros [run-tests] :refer [report]]
-    [figwheel.main.async-result :as async-result]
     [klipse-clj.eval-test]
     [klipse-clj.compile-test]))
 
-;; tests can be asynchronous, we must hook test end
-(defmethod report [:cljs.test/default :end-run-tests] [test-data]
-  (if (cljs.test/successful? test-data)
-    (async-result/send "Tests passed!!")
-    (async-result/throw-ex (ex-info "Tests Failed" test-data))))
+(defn -main []
+  (run-tests (cljs-test-display.core/init! "app-testing")
+             'klipse-clj.eval-test
+             'klipse-clj.compile-test)
+  )
 
-(run-tests (cljs-test-display.core/init! "app-testing")
-           'klipse-clj.eval-test
-           'klipse-clj.compile-test)
+(defn ^:dev/after-load-async start [done]
+  (-main))
+
+(-main)


### PR DESCRIPTION
@viebel, puh this was a little more involved than I though it was.
So, as discussed in https://github.com/viebel/klipse-clj/issues/8#issuecomment-903075855

here are the changes that are necessary to support shadow-cljs
1. a couple of dependency bumps, that made `cljs-map?` and `cljs-seq?` move to `cljs.analyzer.impl`
2. figwheel specific stuff got removed from `klipse-clj.test-runner`, see comment below
3. core will get loaded initially now, as shadow-cljs does not do the infamous `core-dump`. Additionally the core macros need to get their js-source evaluated. Otherwise the analyzer would not be able to do the macro expansion. (By default shadow-cljs will produce an empty core$macro namespace)

with all that, tests are all green, except for one:
`(b= (<! (the-eval "(some? js/React)")) [:ok true])`

This I think is, because figwheel pulls in react automatically.
I assume pulling in react by hand such that this test passes is the way to go?
Anyways, let me know what you think!

EDIT:
forgot to mention, the way the tests get run is like this
`clojure -A:shadow-cljs watch test` 
which will make the test-suite available under `http://localhost:8081/test.html`